### PR TITLE
Fixed path escaping for backslash directory separator on Windows

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -1,3 +1,4 @@
+var slash        = require('slash')
 var through2     = require('through2')
 var getProcessor = require('./processor')
 var pathResolve  = require('path').resolve
@@ -63,6 +64,7 @@ module.exports = function (filename, config) {
 function rPath(cssyFile, sourceFilepath) {
   cssyFile = pathResolve(__dirname, cssyFile);
   cssyFile = pathRelative(dirname(sourceFilepath), cssyFile);
+  cssyFile = slash(cssyFile);
   if(!/^(\.|\/)/.test(cssyFile)) {
     return './' + cssyFile;
   } else {

--- a/package.json
+++ b/package.json
@@ -66,3 +66,4 @@
   "publishConfig": {
     "registry": "http://registry.npmjs.org/"
   }
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "relative-package": "^1.0.0",
     "resolve": "^1.0.0",
     "semver": "^4.2.0",
+    "slash": "^1.0.0",
     "syntax-error": "^1.1.1",
     "through2": "^1.1.1"
   },
@@ -65,4 +66,3 @@
   "publishConfig": {
     "registry": "http://registry.npmjs.org/"
   }
-}


### PR DESCRIPTION
Turns `..\..\..\node_modules\cssy\lib\cssy-browser.js` into `../../../node_modules/cssy/lib/cssy-browser.js` otherwise the injected code is treated as an escaped string and Browserify fails trying to load `node_modulescssylibcssy-browser.js`.
